### PR TITLE
Qc fps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install .
 qiime dev refresh-cache
 ```
 
-q2-qemistree uses [SIRIUS](https://www.nature.com/articles/s41592-019-0344-8), a software-framework developed for de-novo identification of metabolites. We use molecular substrucures predicted by SIRIUS to build a hierarchy of the MS1 features in a dataset. For this demo, please download and unzip the latest version of SIRIUS from [here](https://bio.informatik.uni-jena.de/sirius/). Below, we download SIRIUS for macOS as follows (for linux the only thing that changes is the URL from which the binary is downloaded):
+q2-qemistree uses [SIRIUS](https://www.nature.com/articles/s41592-019-0344-8), a software-framework developed for de-novo identification of metabolites. We use molecular substructures predicted by SIRIUS to build a hierarchy of the MS1 features in a dataset. For this demo, please download and unzip the latest version of SIRIUS from [here](https://bio.informatik.uni-jena.de/sirius/). Below, we download SIRIUS for macOS as follows (for linux the only thing that changes is the URL from which the binary is downloaded):
 
 ```bash
 wget https://bio.informatik.uni-jena.de/repository/dist-release-local/de/unijena/bioinf/ms/sirius/4.0.1/sirius-4.0.1-osx64-headless.zip
@@ -117,7 +117,7 @@ qiime qemistree make-hierarchy \
   --i-csi-results fingerprints.qza \
   --i-csi-results fingerprints2.qza \
   --i-feature-tables feature-table.qza \
-  --i-feature-tables feature-table2.qza
+  --i-feature-tables feature-table2.qza \
   --o-tree merged-qemistree.qza \
   --o-merged-feature-table merged-feature-table.qza \
   --o-merged-feature-data merged-feature-data.qza
@@ -127,7 +127,7 @@ qiime qemistree make-hierarchy \
 
 This method generates the following:
 1. A combined feature table by merging all the input feature tables; MS1 features without fingerprints are filtered out of this feature table. This is done because SIRIUS predicts molecular substructures for a subset of features (typically for 70-90% of all MS1 features) in an experiment (based on factors such as sample type, the quality MS2 spectra, and user-defined tolerances such as `--p-ppm-max`, `--p-zodiac-threshold`). This output is of type `FeatureTable[Frequency]`.
-2. A tree relating the MS1 features in these data based on molecular substructures predicted for MS1 features. This is of type `Phylogeny[Rooted]`. By default, we only use PubChem fingerprints (total 489 molecular properties). Adding `--p-no-qc-properties` retains all (2936) the molecular properties in the contingency table.
+2. A tree relating the MS1 features in these data based on molecular substructures predicted for MS1 features. This is of type `Phylogeny[Rooted]`. By default, we retain all fingerprint positions i.e. 2936 molecular properties). Adding `--p-qc-properties` filters these properties to keep only PubChem fingerprint positions (489 molecular properties) in the contingency table.
 **Note**: The latest release of [SIRIUS](https://www.nature.com/articles/s41592-019-0344-8) uses PubChem version downloaded on 13 August 2017.
 3. A combined feature data file that contains unique identifiers of each feature, their corresponding original feature identifier, and feature tables that each feature was detected in. This is of type `FeatureData[Molecules]`. (The renaming of features needs to be done to avoid overlapping, non-unique feature identifiers in the original feature table)
 

--- a/q2_qemistree/_collate_fingerprint.py
+++ b/q2_qemistree/_collate_fingerprint.py
@@ -16,7 +16,7 @@ from ._semantics import CSIDirFmt
 data = pkg_resources.resource_filename('q2_qemistree', 'data')
 
 
-def collate_fingerprint(csi_result: CSIDirFmt, qc_properties: bool = True):
+def collate_fingerprint(csi_result: CSIDirFmt, qc_properties: bool = False):
     '''
     This function collates predicted chemical fingerprints for mass-spec
     features in an experiment.

--- a/q2_qemistree/_hierarchy.py
+++ b/q2_qemistree/_hierarchy.py
@@ -58,8 +58,8 @@ def merge_feature_data(fdata: pd.DataFrame):
 
 def make_hierarchy(csi_results: CSIDirFmt,
                    feature_tables: biom.Table,
-                   qc_properties: bool = True) -> (TreeNode, biom.Table,
-                                                   pd.DataFrame):
+                   qc_properties: bool = False) -> (TreeNode, biom.Table,
+                                                    pd.DataFrame):
     '''
     This function generates a hierarchy of mass-spec features based on
     predicted chemical fingerprints. It filters the feature table to
@@ -72,7 +72,7 @@ def make_hierarchy(csi_results: CSIDirFmt,
         one or more CSI:FingerID output folder
     feature_table : biom.Table
         one or more feature tables with mass-spec feature intensity per sample
-    qc_properties : bool, default True
+    qc_properties : bool, default False
         flag to filter molecular properties to keep only PUBCHEM fingerprints
 
     Raises


### PR DESCRIPTION
this PR changes qc_properties to False as the default. To reduce false positive merges in fingerprints, we should keep all fingerprint positions (total 2936)
