### PR TITLE
Add a transformer from TSVMolecules to QIIME2 Metadata

### DIFF
--- a/q2_qemistree/_transformer.py
+++ b/q2_qemistree/_transformer.py
@@ -1,6 +1,7 @@
 from .plugin_setup import plugin
 from ._semantics import TSVMolecules
 import pandas as pd
+import qiime2
 
 
 def _read_dataframe(fh):
@@ -25,3 +26,13 @@ def _2(ff: TSVMolecules) -> pd.DataFrame:
     with ff.open() as fh:
         df = _read_dataframe(fh)
         return df
+
+# define a transformer from TSVMolecules -> qiime2.Metadata
+# Based on the other transformers in this file, as well as the
+# TaxonomyFormat -> qiime2.Metadata transformer in q2-types --
+# https://github.com/qiime2/q2-types/blob/dc75cdeeb5e5535bc3c8bc703d06ef0adc1b58f9/q2_types/feature_data/_transformer.py#L170
+@plugin.register_transformer
+def _3(ff: TSVMolecules) -> qiime2.Metadata:
+    with ff.open() as fh:
+        df = _read_dataframe(fh)
+        return qiime2.Metadata(df)


### PR DESCRIPTION
This allows visualization of `FeatureData[Molecules]` artifacts as fancy tables using `qiime metadata tabulate`, and allows the use of these artifacts as feature metadata in Empress (previously trying to use this as feature metadata in Empress would give you an error).

...That being said, feature metadata [isn't currently used for anything](https://github.com/biocore/empress/blob/0f4c98d348ade522474408692551859f99eda10e/empress/_plot.py#L33-L35) by Empress, but I understand this is planned to be changed in the future.