### PR TITLE
convert itol functionality into qiime2 command

### DIFF
--- a/q2_qemistree/_itol.py
+++ b/q2_qemistree/_itol.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import biom
+from qiime2 import CategoricalMetadataColumn
+
+
+def get_itol_barchart(table: biom.Table,
+                      metadata: CategoricalMetadataColumn) -> biom.Table:
+    '''Generate a table in QIIME 2 artifact format which can be directly
+    parsed by iTOL and yield a multi-value bar chart.
+
+    Parameters
+    ----------
+    table : biom.Table
+        Table of feature frequencies by sample.
+    metadata : qiime2.CategoricalMetadataColumn
+        Categorical sample metadata column.
+
+    Returns
+    -------
+    biom.Table
+        Table of mean feature frequencies per category per sample.
+    '''
+    column = metadata.drop_missing_values()
+    catmap = column.to_series().to_dict()
+    return table.collapse(lambda i, _: catmap[i], norm=True, axis='sample')

--- a/q2_qemistree/plugin_setup.py
+++ b/q2_qemistree/plugin_setup.py
@@ -18,8 +18,10 @@ from ._semantics import (MassSpectrometryFeatures, MGFDirFmt,
                          ZodiacFolder, ZodiacDirFmt,
                          CSIFolder, CSIDirFmt,
                          FeatureData, TSVMoleculesFormat, Molecules)
+from ._itol import get_itol_barchart
 
-from qiime2.plugin import Plugin, Str, Range, Choices, Float, Int, Bool, List
+from qiime2.plugin import (Plugin, Str, Range, Choices, Float, Int, Bool, List,
+                           MetadataColumn, Categorical)
 from q2_types.feature_table import FeatureTable, Frequency
 from q2_types.tree import Phylogeny, Rooted
 
@@ -165,11 +167,11 @@ plugin.methods.register_function(
                                        'match for mass-spec features'},
     parameter_descriptions={'qc_properties': 'filters molecular properties to '
                                              'retain PUBCHEM fingerprints',
-                            'metric' : 'metric for hierarchical clustering of '
-                                       'fingerprints. If the Jaccard metric is'
-                                       ' selected, molecular fingerprints are '
-                                       'first binarized (probabilities above '
-                                       '0.5 are True, and False otherwise).'},
+                            'metric': 'metric for hierarchical clustering of '
+                                      'fingerprints. If the Jaccard metric is'
+                                      ' selected, molecular fingerprints are '
+                                      'first binarized (probabilities above '
+                                      '0.5 are True, and False otherwise).'},
     outputs=[('tree', Phylogeny[Rooted]),
              ('feature_table', FeatureTable[Frequency]),
              ('feature_data', FeatureData[Molecules])],
@@ -221,6 +223,21 @@ plugin.methods.register_function(
     outputs=[('pruned_tree', Phylogeny[Rooted])],
     output_descriptions={'pruned_tree': 'Pruned tree of molecules with '
                                         'tips that are in feature data'}
+)
+
+plugin.methods.register_function(
+    function=get_itol_barchart,
+    name='Generate an iTOL bar chart annotation file',
+    description=('Calculate mean frequency per category per sample and render '
+                 'as bar height.'),
+    inputs={'table': FeatureTable[Frequency]},
+    parameters={'metadata': MetadataColumn[Categorical]},
+    input_descriptions={'table': 'Table of feature frequencies by sample.'},
+    parameter_descriptions={'metadata': 'Categorical sample metadata column.'},
+    outputs=[('barchart', FeatureTable[Frequency])],
+    output_descriptions={'barchart': 'Table of mean feature frequencies per '
+                                     'category per sample, which can be '
+                                     'parsed by iTOL and yield a bar chart.'}
 )
 
 importlib.import_module('q2_qemistree._transformer')


### PR DESCRIPTION
Hi @anupriyatripathi I have created the first PR to address issue #100 . It works. It generates a feature table which can be drag & drop into iTOL interface and render as a multi-value bar chart.

However, I refrained from adding the remaining functionality: tip label and clade color, into this module, because I am not sure how to handle it right. As you know, QIIME 2's output file is always .qza. However a .qza file cannot be parsed by iTOL (except for feature table). One still need to unzip it before use. Let alone the trouble of creating two more Artifact types.

I think I may not fully understand the philosophy of QIIME 2 plugin design. I would like to know your opinion of how to proceed. Thank you!
