### PR TITLE
tsv to txt

### DIFF
--- a/q2_qemistree/_plot.py
+++ b/q2_qemistree/_plot.py
@@ -169,11 +169,11 @@ def plot(output_dir: str, tree: NewickFormat, feature_metadata: pd.DataFrame,
                          (category,
                           ', '.join(feature_metadata.columns.astype())))
 
-    color_fp = join(output_dir, 'colors.tsv')
+    color_fp = join(output_dir, 'colors.txt')
     with open(color_fp, 'w') as fh:
         fh.write(format_colors(feature_metadata, category, color_palette))
 
-    label_fp = join(output_dir, 'labels.tsv')
+    label_fp = join(output_dir, 'labels.txt')
     with open(label_fp, 'w') as fh:
         fh.write(format_labels(feature_metadata, category, ms2_label,
                                parent_mz))
@@ -188,7 +188,7 @@ def plot(output_dir: str, tree: NewickFormat, feature_metadata: pd.DataFrame,
     itol_uploader.add_file(label_fp)
     itol_uploader.add_file(color_fp)
     if grouped_table is not None:
-        barplot_fp = join(output_dir, 'barplots.tsv')
+        barplot_fp = join(output_dir, 'barplots.txt')
         with open(barplot_fp, 'w') as fh:
             fh.write(format_barplots(grouped_table))
         itol_uploader.add_file(barplot_fp)

--- a/q2_qemistree/assets/index.html
+++ b/q2_qemistree/assets/index.html
@@ -35,18 +35,18 @@
     </a>
   </div>
   <div class='col-md-3'>
-    <a href='./labels.tsv' target="_blank" rel="noopener noreferrer" class='btn btn-default'>
+    <a href='./labels.txt' target="_blank" rel="noopener noreferrer" class='btn btn-default'>
       Labels
     </a>
   </div>
   <div class='col-md-3'>
-    <a href='./colors.tsv' target="_blank" rel="noopener noreferrer" class='btn btn-default'>
+    <a href='./colors.txt' target="_blank" rel="noopener noreferrer" class='btn btn-default'>
       Colors
     </a>
   </div>
   {% if has_barplots %}
     <div class='col-md-3'>
-      <a href='./barplots.tsv' target="_blank" rel="noopener noreferrer" class='btn btn-default'>
+      <a href='./barplots.txt' target="_blank" rel="noopener noreferrer" class='btn btn-default'>
         Abundance
       </a>
     </div>


### PR DESCRIPTION
Converts downloadable metadata from .tsv to .txt. iTOL only accepts .txt